### PR TITLE
module.exports changes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,6 +154,4 @@ class PesaPal{
 
     
 }
-module.exports ={
-    PesaPal
-}
+module.exports = PesaPal ;


### PR DESCRIPTION
I edited the last line.

`module.exports = {PesaPal}` means that it will be imported as below
```
const {PesaPal} = require('pesapal-node');
new pesapal = new PesaPal ......
```

I have modified the last line to:
`module.exports = PesaPal ;`

so that it can be imported as below :
```
const PesaPal = require('pesapal-node');
new pesapal = new PesaPal ......
```